### PR TITLE
fix prime symbols in tags being ignored

### DIFF
--- a/rr_lib.rb
+++ b/rr_lib.rb
@@ -1641,7 +1641,7 @@ attr_reader :status, :artist, :album, :year, :genre
 
 	# characters that will be changed for tags and filenames
 	def allFilter(var)
-		var.gsub!('`', "'")
+		var.gsub!(/[`´]/, "'")
 		
 		# replace any underscores with spaces, some freedb info got 
 		# underscores instead of spaces


### PR DESCRIPTION
When song tags included the prime symbol `var.gsub!(...) calls would fail with "incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)"
